### PR TITLE
b25による復号失敗時に100回リトライ

### DIFF
--- a/recfriior5/setting.hpp
+++ b/recfriior5/setting.hpp
@@ -8,6 +8,7 @@
 
 // エラー最大表示数
 const uint32_t URB_ERROR_MAX = 20;
+const uint32_t B25_ERROR_MAX = 100;
 
 // 受信サイズ(usbfsのバルク転送限界サイズ)
 const uint32_t TSDATASIZE = 16384;


### PR DESCRIPTION
b25で復号を行う際に、録画を開始し始めるタイミングによっては、復号処理開始時にエラーが発生する。この際、recfriioは復号を行わずにデータを保存する。
このようなデータをb25コマンドにより復号する際には、-S オプションを用いて復号開始位置を後ろにずらすことで復号可能である。
本パッチでは、recfriioがb25を呼び出した際にエラーが生じた場合に、エラーが生じたデータを破棄し、次のデータを受け取った際に最大100回までリトライする。
